### PR TITLE
http status 코드만으로 오류를 정확하게 표현하기 어렵기 떄문에 custom 에러 코드 생성

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,10 @@
+{
+"resutl" : {
+"result_code":200,
+"result_message":"OK",
+"result_description":"성공",
+}
+"body":{
+
+}
+}

--- a/service/api/src/main/java/org/delivery/api/account/AccountApiController.java
+++ b/service/api/src/main/java/org/delivery/api/account/AccountApiController.java
@@ -2,6 +2,9 @@ package org.delivery.api.account;
 
 import lombok.RequiredArgsConstructor;
 import org.delivery.api.account.model.AccountMeResponse;
+import org.delivery.api.common.api.Api;
+import org.delivery.api.common.error.ErrorCode;
+import org.delivery.api.common.error.UserErrorCode;
 import org.delivery.db.account.AccountRepository;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,11 +25,27 @@ public class AccountApiController {
     private final AccountRepository accountRepository;
 
     @GetMapping("/me")
-    public AccountMeResponse me(){
-        return AccountMeResponse.builder()
+    public Api<AccountMeResponse> me(){
+        var response = AccountMeResponse.builder()
                 .name("홍길동")
                 .email("mail@gmila.com")
                 .registeredAt(LocalDateTime.now())
                 .build();
+
+        return Api.OK(response);
+
+    }
+
+    @GetMapping("/me2")
+    public Api<Object> me2(){
+        var response = AccountMeResponse.builder()
+                .name("홍길동")
+                .email("mail@gmila.com")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+//        return Api.OK(response);
+
+        return Api.ERROR(UserErrorCode.USER_NOT_FOUND,"존재하지 않은 유저");
     }
 }

--- a/service/api/src/main/java/org/delivery/api/common/api/Api.java
+++ b/service/api/src/main/java/org/delivery/api/common/api/Api.java
@@ -1,0 +1,51 @@
+package org.delivery.api.common.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.delivery.api.common.error.ErrorCodeIfs;
+
+import javax.validation.Valid;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Api<T> {
+
+    private Result result;
+
+    @Valid
+    private T body;
+
+    public static <T> Api<T> OK(T data){
+        var api = new Api();
+        api.result = Result.OK();
+        api.body = data;
+        return api;
+    }
+
+    public static Api<Object> ERROR(Result result){
+        var api = new Api<Object>();
+        api.result = result;
+        return api;
+    }
+
+    public static Api<Object> ERROR(ErrorCodeIfs errorCodeIfs){
+        var api = new Api<Object>();
+        api.result = Result.ERROR(errorCodeIfs);
+        return api;
+    }
+
+    public static Api<Object> ERROR(ErrorCodeIfs errorCodeIfs, Throwable tx){
+        var api = new Api<Object>();
+        api.result = Result.ERROR(errorCodeIfs, tx);
+        return api;
+    }
+
+    public static Api<Object> ERROR(ErrorCodeIfs errorCodeIfs, String description){
+        var api = new Api<Object>();
+        api.result = Result.ERROR(errorCodeIfs, description);
+        return api;
+    }
+
+}

--- a/service/api/src/main/java/org/delivery/api/common/api/Result.java
+++ b/service/api/src/main/java/org/delivery/api/common/api/Result.java
@@ -1,0 +1,54 @@
+package org.delivery.api.common.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.delivery.api.common.error.ErrorCode;
+import org.delivery.api.common.error.ErrorCodeIfs;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Result {
+
+    private Integer resultCode;
+
+    private String resultMessage;
+
+    private String resultDescription;
+
+
+    public static Result OK(){
+        return Result.builder()
+                .resultCode(ErrorCode.OK.getErrorCode())
+                .resultMessage(ErrorCode.OK.getDescription())
+                .resultDescription("성공")
+                .build();
+    }
+
+    public static Result ERROR(ErrorCodeIfs errorCodeIfs){
+        return Result.builder()
+                .resultCode(errorCodeIfs.getErrorCode())
+                .resultMessage(errorCodeIfs.getDescription())
+                .resultDescription("실패")
+                .build();
+    }
+
+    public static Result ERROR(ErrorCodeIfs errorCodeIfs, Throwable tx){
+        return Result.builder()
+                .resultCode(errorCodeIfs.getErrorCode())
+                .resultMessage(errorCodeIfs.getDescription())
+                .resultDescription(tx.getLocalizedMessage()) //비추
+                .build();
+    }
+
+    public static Result ERROR(ErrorCodeIfs errorCodeIfs, String description){
+        return Result.builder()
+                .resultCode(errorCodeIfs.getErrorCode())
+                .resultMessage(errorCodeIfs.getDescription())
+                .resultDescription(description)
+                .build();
+    }
+}

--- a/service/api/src/main/java/org/delivery/api/common/error/ErrorCode.java
+++ b/service/api/src/main/java/org/delivery/api/common/error/ErrorCode.java
@@ -1,0 +1,22 @@
+package org.delivery.api.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode implements ErrorCodeIfs{
+
+    OK(HttpStatus.OK.value(), 200, "성공"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 요청"),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "서버에러"),
+    NULL_POINT(HttpStatus.INTERNAL_SERVER_ERROR.value(), 512, "Null point"),
+
+    ;
+
+    private final Integer httpStatusCode; //실제 http 에러 코드
+    private final Integer errorCode; //우리가 사용할 에러 코드
+    private final String description; //에러 설명
+
+}

--- a/service/api/src/main/java/org/delivery/api/common/error/ErrorCodeIfs.java
+++ b/service/api/src/main/java/org/delivery/api/common/error/ErrorCodeIfs.java
@@ -1,0 +1,8 @@
+package org.delivery.api.common.error;
+
+public interface ErrorCodeIfs {
+
+    Integer getHttpStatusCode();
+    Integer getErrorCode();
+    String getDescription();
+}

--- a/service/api/src/main/java/org/delivery/api/common/error/UserErrorCode.java
+++ b/service/api/src/main/java/org/delivery/api/common/error/UserErrorCode.java
@@ -1,0 +1,22 @@
+package org.delivery.api.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/*
+ * User의 경우 1000번대 에러코드 사용
+ */
+
+
+@AllArgsConstructor
+@Getter
+public enum UserErrorCode implements ErrorCodeIfs {
+
+    USER_NOT_FOUND(400, 1404, "사용자를 찾을 수 없음."),
+    
+    ;
+    private final Integer httpStatusCode; //실제 http 에러 코드
+    private final Integer errorCode; //우리가 사용할 에러 코드
+    private final String description; //에러 설명
+}


### PR DESCRIPTION
response를 한번 더 감싸서 데이터 body와 추가정보를 client에 제공

{
  "resutl" : {
    "result_code":200,
    "result_message":"OK",
    "result_description":"성공",
  }
  "body":{

  }
}

에러코드가 서비스할수록 늘어나기 때문에 인터페이스를 사용해 실수 방지